### PR TITLE
Docs - Getting Started: Fixed "usage" page links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ Once you have your type, and a reference to Ditto, you can perform a mapping, us
 var viewModel = Model.Content.As<MyViewModel>();
 ```
 
-For more detailed examples, please see the [Basic usage](usage) section, followed by [Advanced usage](usage).
+For more detailed examples, please see the [Basic usage](usage-basic) section, followed by [Advanced usage](usage-advanced-attributes).
 
 
 ## Where do I configure Ditto?


### PR DESCRIPTION
Corrected the "Basic Usage" and "Advanced Usage" links on the Getting Started page.
